### PR TITLE
Fix to support extra args as described in the docs

### DIFF
--- a/src/expressions.js
+++ b/src/expressions.js
@@ -8,8 +8,8 @@ var cache = {};
 exports.globals = {};
 
 
-exports.parse = function(expr, globals, formatters, extraArgs) {
-  if (!Array.isArray(extraArgs)) extraArgs = [];
+exports.parse = function(expr, globals, formatters) {
+  var extraArgs = slice.call(arguments, 3);
   var cacheKey = expr + '|' + extraArgs.join(',');
   // Returns the cached function for this expression if it exists.
   var func = cache[cacheKey];
@@ -37,10 +37,8 @@ exports.parse = function(expr, globals, formatters, extraArgs) {
 
 
 exports.parseSetter = function(expr, globals, formatters, extraArgs) {
-  if (!Array.isArray(extraArgs)) extraArgs = [];
+  var extraArgs = slice.call(arguments, 3);
 
-  // Add _value_ as the first extra argument
-  extraArgs.unshift(valueProperty);
   if (expr.charAt(0) === '!') {
     // Allow '!prop' to become 'prop = !value'
     expr = expr.slice(1).replace(/(\s*\||$)/, ' = !_value_$1');
@@ -48,7 +46,8 @@ exports.parseSetter = function(expr, globals, formatters, extraArgs) {
     expr = expr.replace(/(\s*\||$)/, ' = _value_$1');
   }
 
-  return exports.parse(expr, globals, formatters, extraArgs);
+  // Add _value_ as the first extra argument
+  return exports.parse.apply(exports, [expr, globals, formatters, valueProperty].concat(extraArgs));
 };
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -208,6 +208,19 @@ describe('Expressions.js', function() {
       it('should not fail when a function does not exist', function() {
         expect(callFoo.call({})).to.equal(undefined);
       });
+
+      it('should suppor extra arguments', function() {
+        var callFooBar = expressions.parse('foo(bar, bash)', null, null, 'bar', 'bash');
+        var passedArg1, passedArg2, bar = {}, bash = {};
+        callFooBar.call({
+          foo: function(arg1, arg2) {
+            passedArg1 = arg1;
+            passedArg2 = arg2;
+          }
+        }, bar, bash);
+        expect(passedArg1).to.equal(bar);
+        expect(passedArg2).to.equal(bash);
+      });
     });
 
 


### PR DESCRIPTION
The docs say you can pass extra args like `expressions.parse(expr, globals, formatters, ...args)` but expressions was expecting args to be an array rather than a list of arguments.

This should fix this feature to work as documented. Fortunately no known usages of this feature exist yet.
